### PR TITLE
Fix for pawns with manually assigned loadouts

### DIFF
--- a/Source/EquipmentManagerMapComponent.cs
+++ b/Source/EquipmentManagerMapComponent.cs
@@ -330,9 +330,12 @@ namespace EquipmentManager
                     assignedPawnsCount++;
                 }
             }
-            foreach (var pawn in _pawnCache.Where(pc => pc.AutoLoadout && pc.AssignedLoadout != null))
+            foreach (var pawn in _pawnCache)
             {
-                EquipmentManager.SetPawnLoadout(pawn.Pawn, pawn.AssignedLoadout, true);
+                if (pawn.AutoLoadout && pawn.AssignedLoadout != null)
+                {
+                    EquipmentManager.SetPawnLoadout(pawn.Pawn, pawn.AssignedLoadout, true);
+                }
                 pawn.AssignedWeapons.Clear();
                 pawn.AssignedAmmo.Clear();
             }


### PR DESCRIPTION
Fix for pawns with manually assigned loadouts
not cycling their weapons due to a thrown exception.

Addresses #2 

Tested in my local game.  No more exceptions are thrown, and now pawns with manually set loadouts correctly dump their old weapons and equip new ones.